### PR TITLE
declared pointers to parameter values as pointers to constant variables in the inspectable interface

### DIFF
--- a/selforg/utils/inspectable.cpp
+++ b/selforg/utils/inspectable.cpp
@@ -82,7 +82,7 @@ Inspectable::iconnectionlist Inspectable::getStructuralConnections() const {
   return std::list<IConnection>();
 }
 
-void Inspectable::addInspectableValue(const iparamkey& key, iparamval* val, 
+void Inspectable::addInspectableValue(const iparamkey& key, iparamval const* val,
                                       const std::string& descr) {
   mapOfValues+=iparampair(key,val);
   if(!descr.empty())

--- a/selforg/utils/inspectable.h
+++ b/selforg/utils/inspectable.h
@@ -52,14 +52,14 @@ public:
 
   typedef std::string iparamkey;
   typedef double iparamval;
-  typedef std::pair<iparamkey,iparamval*> iparampair;
+  typedef std::pair<iparamkey,iparamval const*> iparampair;
 
   // the bool says whether  only 4x4AndDiag is used
   typedef std::pair<iparamkey,std::pair< const matrix::Matrix*, bool > > imatrixpair; 
   typedef std::list<iparamkey> iparamkeylist;
   typedef std::list<std::string> infoLinesList;
   typedef std::list<iparamval> iparamvallist;
-  typedef std::list<iparamval*> iparamvalptrlist;
+  typedef std::list<iparamval const *> iparamvalptrlist;
   typedef std::list<iparampair> iparampairlist;
   typedef std::list<imatrixpair> imatrixpairlist;
 
@@ -149,7 +149,7 @@ public:
    * @param val the address of the value to inspect
    * @param descr description string to be exported (using infolines)
    */
-  virtual void addInspectableValue(const iparamkey& key, iparamval* val, 
+  virtual void addInspectableValue(const iparamkey& key, iparamval const * val,
                                    const std::string& descr = std::string());
 
 

--- a/selforg/utils/inspectableproxy.cpp
+++ b/selforg/utils/inspectableproxy.cpp
@@ -34,9 +34,9 @@ InspectableProxy::InspectableProxy(const std::list<Inspectable*>& list, const ip
 	for(std::list<Inspectable*>::const_iterator iter = list.begin(); iter!=list.end(); iter++) {
 		//m_list.push_back(*iter);
 		std::list<std::string> names = (*iter)->getInternalParamNames();
-		std::list<double*> values = (*iter)->getInternalParamsPtr();
+		std::list<double const*> values = (*iter)->getInternalParamsPtr();
 		std::list<std::string>::iterator namesIter = names.begin();
-		std::list<double*>::iterator valuesIter = values.begin();
+		std::list<double const*>::iterator valuesIter = values.begin();
 		unsigned int num = names.size();
 
 		for(unsigned int i = 0; i < num; i++) {
@@ -95,8 +95,8 @@ bool InspectableProxy::replaceList(const std::list<Inspectable*>& list) {
 
 	FOREACHC(std::list<Inspectable*>,list,i) {
 		std::list<std::string> names = (*i)->getInternalParamNames();
-		std::list<double*> values = (*i)->getInternalParamsPtr();
-		std::list<double*>::iterator l = values.begin();
+		std::list<double const *> values = (*i)->getInternalParamsPtr();
+		std::list<double const*>::iterator l = values.begin();
 
 		FOREACH(std::list<std::string>,names,j) {
 			FOREACH(Inspectable::iparampairlist,mapOfValues,k) {


### PR DESCRIPTION
Hello,

I am from the robot group at Goettingen. While working with lpzrobots and especially with the inspectable interface I noticed that it would be much more convenient if the inspectable interface accepted pointers to constant double values. This way you can e. g. define inspectable values for methods of internal objects that return a const reference (const double& object::getSomeValue()). I added some const keywords to achieve this possibility. Compiling using "make all" works fine with this adaptation. I would be happy if this could be merged into lpzrobots.

Best
Timo
