### PR TITLE
Fix contact sensor bug

### DIFF
--- a/ode_robots/robots/amosII.cpp
+++ b/ode_robots/robots/amosII.cpp
@@ -952,10 +952,13 @@ namespace lpzrobots {
           odeHandle.addIgnoredPair(secondThorax, foot);
 
           // leg contact sensor
-          // binary sensor (switch)
-          // legContactSensors[LegPos(i)] = new ContactSensor(true);
-          // force sensor
-          legContactSensors[LegPos(i)] = new ContactSensor(false,50);
+          if (conf.legContactSensorIsBinary) {
+            // binary sensor (switch)
+            legContactSensors[LegPos(i)] = new ContactSensor(true);
+          } else {
+            // force sensor
+            legContactSensors[LegPos(i)] = new ContactSensor(false,50);
+          }
           legContactSensors[LegPos(i)]->init(odeHandle, osgHandle,
               legs[LegPos(i)].foot, false);
         }
@@ -1325,6 +1328,7 @@ namespace lpzrobots {
     c.useBack = _useBack;
     c.rubberFeet = false;
     c.useLocalVelSensor = 0;
+    c.legContactSensorIsBinary = false;
 
     // the trunk length. this scales the whole robot! all parts' sizes,
     // masses, and forces will be adapted!!

--- a/ode_robots/robots/amosII.h
+++ b/ode_robots/robots/amosII.h
@@ -72,6 +72,8 @@ namespace lpzrobots {
        *  If yes it gets velocity vector in local coordinates and pass it as
        *  sensorvalues */
       bool useLocalVelSensor;
+      /** Use binary leg contact sensors. If false, a force sensor is used. */
+      bool legContactSensorIsBinary;
       /**@}*/
 
       /** scaling factor for robot (length of body) */


### PR DESCRIPTION
Hi,
there are some problems with the amosII contact sensors when not using all legs. In detail, assert(reference) fails in the init method of the ContactSensor class. Therefore, I changed the code so that contact sensors are only used when the given leg and the corresponding foot element are activated. I also moved the creation of the contact sensors into the create method as we will get segmentation faults when recreating the robot otherwise. Finally, I added a flag to the amos II config class to determine whether binary of force sensors should be used.
Best regards!
Timo
