### PR TITLE
fixed bug in OSGHeightField::loadFromPPM 

### DIFF
--- a/ode_robots/osg/heightfieldprimitive.cpp
+++ b/ode_robots/osg/heightfieldprimitive.cpp
@@ -86,19 +86,19 @@ namespace lpzrobots {
       Indices* indices = new Indices[(cols-1)*(rows-1)*2];
 
       for(int i=0; i<rows; i++){
-	for(int j=0; j<cols; j++){
-	  vertices[i*cols+j] = Vertex(f->getVertex(i,j));
-	  //  normales[i*cols+j] = Vertex(f->getNormal(i,j));
-	}
+        for(int j=0; j<cols; j++){
+          vertices[i*cols+j] = Vertex(f->getVertex(j,i));
+          //  normales[i*cols+j] = Vertex(f->getNormal(i,j));
+        }
       }
       int k=0;
       for(int i=0; i<rows-1; i++){
-	for(int j=0; j<cols-1; j++){
-	  indices[k] = Indices((i+1)*cols+j, i*cols+j+1, i*cols+j);
-	  k++;
-	  indices[k] = Indices((i+1)*cols+j, (i+1)*cols+j+1, i*cols+j+1);
-	  k++;
-	}
+        for(int j=0; j<cols-1; j++){
+          indices[k] = Indices(i*cols+j, i*cols+j+1, (i+1)*cols+j);
+          k++;
+          indices[k] = Indices(i*cols+j+1, (i+1)*cols+j+1, (i+1)*cols+j);
+          k++;
+        }
       }
       assert(k==(cols-1)*(rows-1)*2);
       data = dGeomTriMeshDataCreate();

--- a/ode_robots/osg/osgheightfield.cpp
+++ b/ode_robots/osg/osgheightfield.cpp
@@ -77,8 +77,8 @@ namespace lpzrobots {
     field->setXInterval(x_size/(float)(cols-1));
     field->setYInterval(y_size/(float)(rows-1));
     // scale the height // Todo: find out maximum, currently 1 is assumed
-    for(int i=0; i< rows; i++){
-      for(int j=0; j< cols; j++){
+    for(int i=0; i< cols; i++){
+      for(int j=0; j< rows; j++){
 	field->setHeight(i,j, field->getHeight(i,j) * height);  
       }
     }
@@ -153,8 +153,8 @@ namespace lpzrobots {
     
     // copy and convert the image from RGB chars to double heights
     unsigned char* data = image.data();
-    for(int j=0; j< cols; j++){
-      for(int i=0; i< rows; i++){
+    for(int j=0; j< rows; j++){
+      for(int i=0; i< cols; i++){
 	// use the coding to get the height value and scale it with height
 	field->setHeight(i,j, coding(codingMode, data) * height);  
 	data+=3;


### PR DESCRIPTION
I fixed a bug in OSGHeightField::loadFromPPM that made loading of ppm files with different side lengths crash with segmentation fault. There were just two loop limits mixed up...
Yours, Timo
