### PR TITLE
fixing and adding missing .gitignore files

### DIFF
--- a/ode_robots/examples/sphericalrobot/.gitignore
+++ b/ode_robots/examples/sphericalrobot/.gitignore
@@ -1,1 +1,5 @@
-Makefile.depend start* *.log Makefile
+Makefile.depend 
+start* 
+*.log 
+Makefile
+

--- a/ode_robots/simulations/template_ashigaru/.gitignore
+++ b/ode_robots/simulations/template_ashigaru/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+start
+Makefile.depend

--- a/ode_robots/simulations/template_nejihebi/.gitignore
+++ b/ode_robots/simulations/template_nejihebi/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+start
+Makefile.depend


### PR DESCRIPTION
These .gitignores files were missing / corrupted resulting in Makefiles being reported as untracked in a fresh lpzrobots setup.
