### PR TITLE
Change logic for calling restart() in main loop

### DIFF
--- a/ode_robots/simulation.cpp
+++ b/ode_robots/simulation.cpp
@@ -502,7 +502,7 @@ namespace lpzrobots {
       globalData.createConfigurator();
 
     while ( ( noGraphics || !viewer->done()) &&
-            !simulation_time_reached && restart(odeHandle,osgHandle,globalData) ) {
+            !simulation_time_reached && !restart(odeHandle,osgHandle,globalData) ) {
       if (simulation_time_reached) {
         printf("%li min simulation time reached (%li steps) -> simulation cycle (%i) stopped\n",
                (globalData.sim_step/6000), globalData.sim_step, currentCycle);


### PR DESCRIPTION
This change will mean that
1) restart() actually gets called every simulation loop
2) A simulation can be restart by an overloaded version of Simulation::restart() simply returning true.

restart() doesn't seem to be used much in the main repo, but there are a couple of simulations that might need modification.